### PR TITLE
Fixed size previews using css object-fit

### DIFF
--- a/src/components/research-demo.js
+++ b/src/components/research-demo.js
@@ -35,14 +35,26 @@ class ResearchDemo extends LitElement {
             a:visited {
                 color: gray;
             }
-            .preview { 
-                width: 100%; 
-                height: 150px; 
-                display: flex; 
+            .preview {
+                width: 100%;
+                height: 150px;
+                display: flex;
                 justify-content: center;
                 align-items: flex-start;
             }
-            .preview img {max-width: 100%; height: auto; max-height: 100%;}
+            .preview img {
+                max-width: 100%;
+                height: 100%;
+                object-fit: cover;
+            }
+            .preview .jsgif {
+                height: 100%
+            }
+            .preview .jsgif canvas {
+                width: 100%;
+                height: 100%;
+                object-fit: cover;
+            }
             .description {
                 background: whitesmoke;
                 position: absolute;


### PR DESCRIPTION
Om de previews altijd dezelfde grootte te laten zijn. Behoudt de aspect ratio door een beetje in te zoomen als hij niet fit. Hiervoor wordt css object-fit gebruikt. Dit wordt [prima ondersteund, 96% van internet gebruikers heeft een browser die het ondersteund.](https://caniuse.com/#feat=object-fit) Bij hele oude browsers zal er wel wat vervorming zijn.

Ziet er naar mijn mening beter uit, maar kijk maar of je er wat mee doet ;-)